### PR TITLE
Capture (most) indirect calls

### DIFF
--- a/adhoc-test.sh
+++ b/adhoc-test.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+
+set -o errexit -o pipefail -o nounset
+
+if (( $# != 0 )); then
+    >&2 echo "Usage: $0"
+    exit 2
+fi
+
+temp_dir="$( mktemp -d )"
+trap 'rm -fr "${temp_dir}"' EXIT
+
+cat > "${temp_dir}/compile_commands.json" <<EOF
+[
+  {
+    "directory": "${temp_dir}",
+    "command": "cc -std=c99 -c test.c",
+    "file": "${temp_dir}/test.c",
+    "output": "${temp_dir}/test.o"
+  }
+]
+EOF
+
+cat > "${temp_dir}/test.c" <<EOF
+#define A __attribute__((__annotate__(("hello"))))
+typedef void (T)(void) A;
+typedef void (*U)(void) A;
+typedef void A V A;
+
+struct S {
+    V (*f)(void);
+    T *g;
+    U h;
+    A int (*const j)(int);
+};
+
+static void func1(void) {}
+static A void func2(void) {}
+
+static struct S MY_S = { .f = func1, .g = &func1, .h = (func1) };
+
+static void func3(struct S *s3) A {
+    V (*const f)(void);
+    f();
+
+    struct S s1, *s2;
+
+    func3(s3);
+    s1.f();
+    s2->g();
+    (*s1.h)();
+    (*s2->j)(42);
+
+    s1.f  =  func2;
+    s1.g=&func2;
+    (s1.h)
+        = (func2);
+}
+EOF
+
+cat > "${temp_dir}/expected-vrc-file" <<EOF
+node func1 ${temp_dir}/test.c
+node func2 ${temp_dir}/test.c
+node func3 ${temp_dir}/test.c
+node S::f ${temp_dir}/test.c
+node S::g ${temp_dir}/test.c
+node S::h ${temp_dir}/test.c
+node S::j ${temp_dir}/test.c
+label function_pointer S::f
+label function_pointer S::g
+label function_pointer S::h
+label function_pointer S::j
+label hello func2
+label hello func3
+label hello S::g
+label hello S::h
+label hello S::j
+edge S::f func1 call
+edge S::g func1 call
+edge S::h func1 call
+edge func3 func3 call
+edge func3 S::f call
+edge func3 S::g call
+edge func3 S::h call
+edge func3 S::j call
+edge S::f func2 call
+edge S::g func2 call
+edge S::h func2 call
+EOF
+
+repo_root="$( dirname "$0" | xargs readlink -e )"
+cd "${repo_root}"
+
+meson setup build
+meson compile -C build
+
+meson devenv -C build python -m vrc -C "${temp_dir}" <<EOF
+load --force --loader clang ${temp_dir}/test.o
+save ${temp_dir}/vrc-file
+EOF
+
+diff <( sort "${temp_dir}/expected-vrc-file" ) <( sort "${temp_dir}/vrc-file" )

--- a/vrc/cli/commands.py
+++ b/vrc/cli/commands.py
@@ -225,7 +225,7 @@ class LoadCommand(VRCCommand):
                             help="Report progress while parsing")
         parser.add_argument("--force", action="store_true",
                             help="Do not use cached result")
-        parser.add_argument("--loader", default="rtl",
+        parser.add_argument("--loader", default="clang",
                             help="Pick how to analyze the translation unit")
         parser.add_argument("files", metavar="FILE", nargs="+",
                             help="Dump or object file to be loaded")

--- a/vrc/loaders/cparser.cc
+++ b/vrc/loaders/cparser.cc
@@ -250,20 +250,14 @@ enum CXChildVisitResult visit_function_body(CXCursor c, CXCursor parent, Visitor
 
     switch (c.kind) {
     case CXCursor_CallExpr:
-        {
-            CXCursor target = clang_getCursorReferenced(c);
-            if (!clang_isInvalid(target.kind)) {
-                add_edge(state, state->current_function, target, true);
-            }
+        if (auto target = find_referenced(c)) {
+            add_edge(state, state->current_function, *target, true);
         }
         break;
 
     case CXCursor_FunctionDecl:
-        {
-            CXCursor target = clang_getCursorReferenced(c);
-            if (!clang_isInvalid(target.kind)) {
-                add_edge(state, state->current_function, target, false);
-            }
+        if (auto target = find_referenced(c)) {
+            add_edge(state, state->current_function, *target, false);
         }
         break;
 


### PR DESCRIPTION
- Encode function pointer struct fields as nodes.
- When such a field is initialized with/assigned a function, emit an edge from the field to the function.
- When such a field is invoked, emit an edge from the caller to the field.

This allows us to follow calls through function pointer struct fields, as long as they are initialized with a designated initializer or directly assigned a function, and invoked directly. This should cover most cases that we care about. Covering all possible cases of indirect calls is infeasible.

TODO:

- [x] Follow typedefs to find all function pointer field annotations.
- [x] Emit edges for assignments to function pointer struct fields.
- [x] Emit edges for indirect calls that dereference the pointer (*e.g.*, `(*f)()`).
- [x] Create some output comparison tests to check all this fragile logic.